### PR TITLE
Contextual Menus to render flows + logger + Auto-activation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sfflowvisualiser",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sfflowvisualiser",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "ISC",
       "dependencies": {
         "@vscode/webview-ui-toolkit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "Mermaid",
     "Diagram"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "workspaceContains:sfdx-project.json"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
@@ -33,6 +35,20 @@
         {
           "command": "sfflowvisualiser.generateWebview",
           "when": "editorLangId == xml"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "sfflowvisualiser.generateWebview",
+          "when": "resourceExtname == '.xml'",
+          "group": "z_sfflowvisualiser@3"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "sfflowvisualiser.generateWebview",
+          "when": "resourceExtname == '.xml'",
+          "group": "z_sfflowvisualiser@3"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,21 +1,67 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import { FlowPanel } from "./panels/FlowPanel";
 import { parseFlow } from "salesforce-flow-visualiser";
+import { Logger } from "./logger";
 
 export function activate(context: vscode.ExtensionContext) {
+  new Logger(vscode.window);
   let renderWebView = vscode.commands.registerCommand(
     "sfflowvisualiser.generateWebview",
-    () => {
-      generateWebView(context.extensionUri, "mermaid");
-    },
+    async (flowUri: vscode.Uri | undefined) => {
+      // If no URI is sent via VsCode event, get the uri of the currently active document
+      if (!flowUri) {
+        flowUri = vscode.window.activeTextEditor?.document.uri;
+      }
+      generateWebView(flowUri, context, "mermaid");
+    }
   );
 
   context.subscriptions.push(renderWebView);
 }
 
-async function getParsedXML(mode: any, options: any) {
+async function generateWebView(
+  flowFileUri: vscode.Uri | undefined,
+  context: vscode.ExtensionContext,
+  mode: any
+) {
+  // Check if a file is selected
+  if (!flowFileUri) {
+    vscode.window.showErrorMessage(
+      "You need to select / open a Flow to render it :)"
+    );
+    return;
+  }
+
+  // Check if the selected XML file is a Flow
+  const filePath = flowFileUri.fsPath;
+  if (!filePath.endsWith(".flow-meta.xml")) {
+    vscode.window.showErrorMessage("You can only render Flow metadatas :)");
+    return;
+  }
+
+  // Request flow rendering
+  try {
+    Logger.log(`Prepare rendering of Flow ${path.basename(filePath)}...`);
+    const parsedXmlRes = await getParsedXML(mode, flowFileUri, {
+      wrapInMarkdown: false,
+    });
+    // If there is already a panel, close it (not ideal but... messy behavior if I don't do that ^^)
+    if (FlowPanel.currentPanel) {
+      FlowPanel.currentPanel.dispose();
+    }
+    // Render new panel
+    FlowPanel.render(context.extensionUri, parsedXmlRes);
+    Logger.log(`Rendered flow ${path.basename(filePath)}`);
+  } catch (error) {
+    Logger.log(`Render error:\n${JSON.stringify(error, null, 2)}`);
+  }
+}
+
+async function getParsedXML(mode: any, flowFileUri: vscode.Uri, options: any) {
   return new Promise(async (resolve, reject) => {
-    const xmlData = vscode.window.activeTextEditor?.document.getText();
+    const document = await vscode.workspace.openTextDocument(flowFileUri);
+    const xmlData = document.getText();
     try {
       const res = await parseFlow(xmlData as string, mode, options);
       resolve(res);
@@ -23,15 +69,6 @@ async function getParsedXML(mode: any, options: any) {
       reject(error);
     }
   });
-}
-
-async function generateWebView(extensionUri: vscode.Uri, mode: any) {
-  try {
-    const parsedXmlRes = await getParsedXML(mode, { wrapInMarkdown: false });
-    FlowPanel.render(extensionUri, parsedXmlRes);
-  } catch (error) {
-    console.error(error);
-  }
 }
 
 export function deactivate() {}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,25 @@
+let loggerInstance: Logger;
+
+export class Logger {
+  outputChannel: any;
+
+  constructor(vsCodeWindow: any) {
+    this.outputChannel = vsCodeWindow.createOutputChannel("SF Flow Visualiser");
+    loggerInstance = this;
+  }
+
+  static log(str: any): void {
+    if (loggerInstance) {
+      console.log(str);
+      for (const line of str.toString().split("\n")) {
+        loggerInstance.outputChannelLog(line);
+      }
+    } else {
+      console.log(str);
+    }
+  }
+
+  outputChannelLog(str: string) {
+    this.outputChannel.appendLine(str);
+  }
+}


### PR DESCRIPTION
Contextual menus to render flows:
- From explorer (right click)
- From within the flow XML (right click)

Display logs in a dedicated output section

Activate extension if sfdx-project.json found

![image](https://github.com/user-attachments/assets/f530f1d0-4760-48d1-a316-3c1c1d3f818b)

![image](https://github.com/user-attachments/assets/0c646bf4-becf-4bcb-9d5a-e4b4e7246975)

![image](https://github.com/user-attachments/assets/419f9ec8-a755-4020-b806-395506e062db)

![image](https://github.com/user-attachments/assets/ef4422f3-c91c-489f-8a47-399d165949ab)


